### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/gtagger/geniatagger-3.0.1/bidir.cpp
+++ b/src/gtagger/geniatagger-3.0.1/bidir.cpp
@@ -63,8 +63,6 @@ mesample(const vector<Token> &vt, int i,
     if (str.size() >= j) {
       sprintf(buf, "suf%d_%s", j, str.substr(str.size() - j).c_str());
       sample.features.push_back(buf);
-    }
-    if (str.size() >= j) {
       sprintf(buf, "pre%d_%s", j, str.substr(0, j).c_str());
       sample.features.push_back(buf);
     }

--- a/src/gtagger/geniatagger-3.0.1/maxent.cpp
+++ b/src/gtagger/geniatagger-3.0.1/maxent.cpp
@@ -494,6 +494,7 @@ ME_Model::train(const int cutoff,
     cerr << "number of active features = " << sum << endl;
   }
   
+  return 1;
 }
 
 void

--- a/src/nersuite/FExtor.cpp
+++ b/src/nersuite/FExtor.cpp
@@ -761,7 +761,7 @@ namespace NER
 		}else if (rel_pos < 0) {
 			if (distance(i_row, one_sent.begin()) <= rel_pos)		// begin(), B, (cur), D, E, ... => distance(cur, begin()) = -2
 				ret_word = (*(i_row + rel_pos))[ col ];
-		}else if (rel_pos > 0) {
+		}else {
 			if (distance(i_row, one_sent.end()) > rel_pos  )		// D, E, (cur), G, H, end() => distance(cur, end()) = 3, but only rel_pos = 1 and 2 is accessible
 				ret_word = (*(i_row + rel_pos))[ col ];
 		}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V581](https://www.viva64.com/en/w/v581/) The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 63, 67. bidir.cpp 67
[V547](https://www.viva64.com/en/w/v547/) Expression 'rel_pos > 0' is always true. fextor.cpp 764
[V591](https://www.viva64.com/en/w/v591/) Non-void function should return a value. maxent.cpp 497