### PR TITLE
Updated nersuite_tokenizer exit codes to meet unix conventions.

### DIFF
--- a/src/tokenizer/run.tokenizer.cpp
+++ b/src/tokenizer/run.tokenizer.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
 			string arg = argv[i];
 			if( arg == "--help" ) {
 				cerr << "Usage: " << argv[0] << " < a sentence-per-line file" << endl;
-				return 0;
+				return 1;
 			}
 		}
 	}
@@ -42,7 +42,6 @@ int main(int argc, char* argv[])
 
 	string  line = "";
 	V2_STR  data;
-	int	    n_lines = 1;
 	int     base_offset = 0;
 	bool    prev_comment = false;
 
@@ -92,9 +91,7 @@ int main(int argc, char* argv[])
 			cout << endl;
 		}
 		cout << endl;
-
-		++n_lines;
 	}
 	
-	return n_lines;
+	return 0;
 }


### PR DESCRIPTION
The current exit codes, which are, 0 after help invocation and non-0 (# of processed lines) after normal text processing, are not consistent with Unix conventions and with Makefile workflow. 0 should be used for indicating a success, and non-0 for indicating a failure/inability to continue. The current set of exit codes does not allow to build nersuite_tokenizer into a unix pipeline:

nersuite_tokenizer < input.txt | nersuite_gtagger | nersuite tag <...>

This pipeline always breaks at the first command due to nersuite_tokenizer returning non-0, so currently the user needs a hack like returning a bogus 0 exit code:

nersuite_tokenizer < input.txt; (exit 0) | nersuite_gtagger | nersuite tag <...>